### PR TITLE
[#35] Add filter for today stats

### DIFF
--- a/rs-lang/src/components/molecules/Sticker/Sticker.css
+++ b/rs-lang/src/components/molecules/Sticker/Sticker.css
@@ -1,7 +1,9 @@
 .sticker {
   display: flex;
   padding: 2rem;
+
   max-width: 28rem;
+  width: 100%;
 
   flex-direction: column;
   gap: 2rem;
@@ -19,6 +21,9 @@
 }
 
 @media (max-width: 636px) {
+  .sticker {
+    max-width: 37rem;
+  }
   .sticker__icon,
   .sticker__heading {
     text-align: center;

--- a/rs-lang/src/components/molecules/TeamCard/TeamCard.css
+++ b/rs-lang/src/components/molecules/TeamCard/TeamCard.css
@@ -24,14 +24,13 @@
 }
 
 .team-card__image {
+  height: 36rem;
   max-width: 36rem;
-  max-height: 36rem;
   width: 100%;
 }
 
 .team-card__image img {
   width: 36rem;
-  /* height: 36rem; */
   width: 100%;
   border-radius: 100%;
 
@@ -118,6 +117,9 @@
   .team-card__content p {
     font-size: 2rem;
     line-height: 2.4rem;
+  }
+  .team-card__image {
+    display: none;
   }
 }
 

--- a/rs-lang/src/components/molecules/TeamCard/TeamCard.tsx
+++ b/rs-lang/src/components/molecules/TeamCard/TeamCard.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import Icon from '../../atoms/Icon/Icon'
 import './TeamCard.css'
+import dimaPNG from './images/dima.png'
+import aldarPNG from './images/aldar.jpg'
+import viktorPNG from './images/viktor.jpg'
 
 interface TeamCardProps {
   type: 'dmitry' | 'aldar' | 'viktor'
@@ -14,7 +17,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ type }) => {
           <div className='team-card__info'>
             <div className='team-card__image'>
               <img
-                src={require('./images/dima.png')}
+                src={dimaPNG}
                 alt="dmitry"
               />
             </div>
@@ -47,7 +50,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ type }) => {
           <div className='team-card__info'>
             <div className='team-card__image'>
               <img
-                src={require('./images/aldar.jpg')}
+                src={aldarPNG}
                 alt="aldar"
               />
             </div>
@@ -80,7 +83,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ type }) => {
           <div className='team-card__info'>
             <div className='team-card__image'>
               <img
-                src={require('./images/viktor.jpg')}
+                src={viktorPNG}
                 alt="viktor"
               />
             </div>

--- a/rs-lang/src/components/organisms/Hero/Hero.css
+++ b/rs-lang/src/components/organisms/Hero/Hero.css
@@ -97,9 +97,18 @@
     padding: 12rem 2rem 6rem;
     flex-direction: column-reverse;
   }
+  .hero__content {
+    align-items: center;
+  }
   .hero__heading {
     font-size: 4rem;
     line-height: 4.4rem;
+    text-align: center;
+  }
+  .hero__image {
+    max-width: 39rem;
+
+    text-align: center;
   }
 }
 

--- a/rs-lang/src/components/organisms/Try/Try.css
+++ b/rs-lang/src/components/organisms/Try/Try.css
@@ -46,14 +46,6 @@
   .try__content {
     gap: 2rem;
   }
-  .try__content h2 {
-    font-size: 2.6rem;
-    line-height: 3rem;
-  }
-  .try__content p {
-    font-size: 1.8;
-    line-height: 2.2rem;
-  }
 }
 
 @media (max-width: 960px) {
@@ -61,11 +53,49 @@
     padding: 3rem 2rem;
   }
   .try__content h2 {
+    font-size: 2.6rem;
+    line-height: 3rem;
+  }
+  .try__content p {
+    font-size: 1.8rem;
+    line-height: 2.2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .try__container {
+    padding: 3rem 2rem;
+
+    flex-direction: column-reverse;
+    align-items: center;
+  }
+  .try__content {
+    max-width: 40rem;
+
+    align-items: center;
+    gap: 2rem;
+  }
+  .try__content p {
+    text-align: center;
+  }
+  .try__image {
+    max-width: 40rem;
+  }
+}
+
+@media (max-width: 460px) {
+  .try__container {
+    padding: 2rem 2rem;
+  }
+  .try__content {
+    gap: 1.2rem;
+  }
+  .try__content h2 {
     font-size: 2.4rem;
     line-height: 2.6rem;
   }
   .try__content p {
-    font-size: 1.6;
+    font-size: 1.6rem;
     line-height: 2rem;
   }
 }

--- a/rs-lang/src/components/templates/StatisticsPage/StatisticsPage.tsx
+++ b/rs-lang/src/components/templates/StatisticsPage/StatisticsPage.tsx
@@ -101,7 +101,9 @@ const StatisticsPage: React.FC = () => {
     void getUserTodayStats()
       .then((res) => {
         if (typeof res !== 'string') {
-          setTodayStats(res)
+          if ((new Date(res.date)).getDay() === (new Date()).getDay()) {
+            setTodayStats(res)
+          }
         }
       })
   }, [])


### PR DESCRIPTION
1.  if the date of the current user's statistics does not match the current one, the default statistics are displayed

![image](https://user-images.githubusercontent.com/95768260/190477657-e6865789-7998-4db4-8170-c2e5215fc5c1.png)